### PR TITLE
Fix channel size in CNN conv block

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -6,7 +6,8 @@ class CNN(nn.Module):
     def __init__(self, input_shape: int, hidden_units: int, output_shape: int):
         super().__init__()
         self.conv_block_1 = nn.Sequential(
-            nn.Conv2d(in_channels=input_shape, out_channels=output_shape, kernel_size=3, stride=1, padding=1),
+            # First convolution increases channel depth to the hidden unit size
+            nn.Conv2d(in_channels=input_shape, out_channels=hidden_units, kernel_size=3, stride=1, padding=1),
             nn.BatchNorm2d(hidden_units),
             nn.ReLU(),
             nn.Conv2d(in_channels=hidden_units, out_channels=hidden_units, kernel_size=3, stride=1, padding=1),


### PR DESCRIPTION
## Summary
- fix the first convolution output channel size in `CNN`

## Testing
- `pip install torch==2.3.0 torchvision==0.18.0` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_683ff83a020883248e9292098bdecf2d